### PR TITLE
fix: Update thumbprints

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,10 @@ data "tls_certificate" "this" {
 }
 
 locals {
-  github_thumbprints = [for x in data.tls_certificate.this.certificates : x.sha1_fingerprint]
+  github_thumbprints = distinct(concat(
+    [for x in data.tls_certificate.this.certificates : x.sha1_fingerprint if x.is_ca],
+    var.github_oidc_thumbprints
+  ))
 }
 
 data "aws_iam_openid_connect_provider" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,15 @@ variable "github_oidc_audience" {
   default     = "sts.amazonaws.com"
 }
 
+variable "github_oidc_thumbprints" {
+  description = "A list of known thumbprints for the OpenID Connect (OIDC). ref.[GitHub Actions – Update on OIDC integration with AWS](https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/)"
+  type        = list(string)
+  default     = [
+    "6938fd4d98bab03faadb97b34396831e3780aea1",
+    "1c58a3a8518e8759bf075b76b750d4f2df264fcd",
+  ]
+}
+
 variable "iam_roles" {
   description = <<-EOT
     {


### PR DESCRIPTION
ref. [GitHub Actions – Update on OIDC integration with AWS \| GitHub Changelog](https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/)

Workaround:
Since the value obtained from the URL is not fixed, add the publicly available thumbprints as constant values.
