### PR TITLE
feat: Replace managed_policy_arns to aws_iam_role_policy_attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ No modules.
 |------|------|
 | [aws_iam_openid_connect_provider.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_openid_connect_provider.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_openid_connect_provider) | data source |
 | [aws_iam_policy_document.this_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [tls_certificate.this](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/certificate) | data source |
@@ -43,6 +44,7 @@ No modules.
 | <a name="input_create_oidc_provider"></a> [create\_oidc\_provider](#input\_create\_oidc\_provider) | Create a new identity provider. | `bool` | `true` | no |
 | <a name="input_github_oidc_audience"></a> [github\_oidc\_audience](#input\_github\_oidc\_audience) | Also known as client ID, audience is a value that identifies the application that is registered with an OpenID Connect provider. | `string` | `"sts.amazonaws.com"` | no |
 | <a name="input_github_oidc_domain"></a> [github\_oidc\_domain](#input\_github\_oidc\_domain) | The domain of the identity provider. Corresponds to the iss claim. | `string` | `"token.actions.githubusercontent.com"` | no |
+| <a name="input_github_oidc_thumbprints"></a> [github\_oidc\_thumbprints](#input\_github\_oidc\_thumbprints) | A list of known thumbprints for the OpenID Connect (OIDC). ref.[GitHub Actions – Update on OIDC integration with AWS](https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/) | `list(string)` | <pre>[<br>  "6938fd4d98bab03faadb97b34396831e3780aea1",<br>  "1c58a3a8518e8759bf075b76b750d4f2df264fcd"<br>]</pre> | no |
 | <a name="input_iam_roles"></a> [iam\_roles](#input\_iam\_roles) | {<br>    "iam\_role\_name": {<br>        #e.g. `["repo:{GitHubOrg}/{RepositoryName}:\*", "repo:octo-org/octo-repo:ref:refs/heads/octo-branch"]`<br>        oidc\_claims = ["A list of server certificate thumbprints for the OpenID Connect (OIDC) identity provider's server certificate(s)."]<br>        #e.g. `["arn:aws:iam::aws:policy/ReadOnlyAccess"]`<br>        policy\_arns = ["Set of IAM policy ARNs to attach to the IAM role."]<br>    }<br>} | <pre>map(object({<br>    oidc_claims = list(string)<br>    policy_arns = list(string)<br>  }))</pre> | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to resources. | `map(string)` | `{}` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -68,11 +68,32 @@ data "aws_iam_policy_document" "this_assume_role_policy" {
 }
 
 resource "aws_iam_role" "this" {
-  for_each            = var.iam_roles
-  name                = each.key
-  assume_role_policy  = data.aws_iam_policy_document.this_assume_role_policy[each.key].json
-  managed_policy_arns = each.value.policy_arns
+  for_each           = var.iam_roles
+  name               = each.key
+  assume_role_policy = data.aws_iam_policy_document.this_assume_role_policy[each.key].json
   tags = merge(var.tags, {
     Name = each.key
   })
+}
+
+locals {
+  aws_iam_role_policy_attachment_list = flatten([
+    for k, v in var.iam_roles : [
+      for policy_arn in v.policy_arns : {
+        role_name  = k
+        policy_arn = policy_arn
+      }
+    ]
+  ])
+  aws_iam_role_policy_attachment_map = {
+    for v in local.aws_iam_role_policy_attachment_list : "${v.role_name}/${v.policy_arn}" => v
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "this" {
+  depends_on = [aws_iam_role.this]
+  for_each   = local.aws_iam_role_policy_attachment_map
+
+  role       = each.value.role_name
+  policy_arn = each.value.policy_arn
 }

--- a/variables.tf
+++ b/variables.tf
@@ -19,7 +19,7 @@ variable "github_oidc_audience" {
 variable "github_oidc_thumbprints" {
   description = "A list of known thumbprints for the OpenID Connect (OIDC). ref.[GitHub Actions – Update on OIDC integration with AWS](https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/)"
   type        = list(string)
-  default     = [
+  default = [
     "6938fd4d98bab03faadb97b34396831e3780aea1",
     "1c58a3a8518e8759bf075b76b750d4f2df264fcd",
   ]


### PR DESCRIPTION
ref

```
# https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md

5.72.0 (October 15, 2024)
resource/aws_iam_role: The managed_policy_arns argument is deprecated. Use the aws_iam_role_policy_attachments_exclusive resource instead. (#39718)
```